### PR TITLE
fix: add comment prompting isPending styling

### DIFF
--- a/exercises/05.actions/01.problem.action-reference/ui/edit-text.js
+++ b/exercises/05.actions/01.problem.action-reference/ui/edit-text.js
@@ -22,6 +22,8 @@ export function EditableText({ id, shipId, initialValue = '' }) {
 	const buttonRef = useRef(null)
 	return h(
 		'div',
+		// 🐨 set the style prop on this div to decrease the opacity when the form is submitting
+		// something like { opacity: isPending ? 0.6 : 1 } should work
 		null,
 		edit
 			? h(


### PR DESCRIPTION
Adds a comment on the initial server actions exercise prompting people to add pending styling on the parent div in edit-text.

adding the styling was done in the "solution" to this exercise, but there's no comment in the problem prompting people to do that. Wasn't 100% sure what the wording should be, tried to word it similar to other comments