### PR TITLE
Docs: Clarify popstate handling to prevent UI freeze on navigation spam

### DIFF
--- a/exercises/04.router/05.problem.cache/ui/index.js
+++ b/exercises/04.router/05.problem.cache/ui/index.js
@@ -61,6 +61,7 @@ function Root() {
 
 			// 🐨 change this to setContentKey(historyKey)
 			startTransition(() => setContentPromise(nextContentPromise))
+			// 🐨 otherwise, setContentKey(historyKey) directly (no transition needed)
 		}
 		window.addEventListener('popstate', handlePopState)
 		return () => window.removeEventListener('popstate', handlePopState)

--- a/exercises/04.router/05.solution.cache/ui/index.js
+++ b/exercises/04.router/05.solution.cache/ui/index.js
@@ -56,9 +56,10 @@ function Root() {
 				const fetchPromise = fetchContent(nextLocation)
 				const nextContentPromise = createFromFetch(fetchPromise)
 				contentCache.set(historyKey, nextContentPromise)
+				startTransition(() => setContentKey(historyKey))
+			} else {
+				setContentKey(historyKey)
 			}
-
-			startTransition(() => setContentKey(historyKey))
 		}
 		window.addEventListener('popstate', handlePopState)
 		return () => window.removeEventListener('popstate', handlePopState)


### PR DESCRIPTION
### Summary
This PR updates the exercise instructions / solution to address a performance bug that could freeze the UI when repeatedly pressing the back/forward navigation buttons.

### The Problem
Previously, every `popstate` update including those already served from cache was wrapped in `startTransition`. When the back/forward buttons were spammed, React’s concurrent scheduler queued up a large number of unnecessary transitions, causing heavy reconciliation work and freezing the browser tab.

### The Fix
The instructional comments in now clarify the correct handling for each case:

- **Cache hits:** Update state directly (no transition).<br/>
- **Cache misses:** Fetch new content and wrap the state update in `startTransition`.

This distinction ensures the UI stays responsive, even under rapid navigation.