### PR TITLE
ci: allow workshops without a typecheck script

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -83,27 +83,16 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 26
+          # Playwright 1.51's browser install and test runner hang under Node 26.
+          # The setup matrix above still validates the workshop under Node 26.
+          node-version: 22
 
       - name: 📦 Install dependencies
         run: npm ci
 
-      # Playwright 1.51 hangs while extracting Chromium under Node 26.
-      - name: ⎔ Use Node 22 for Playwright installation
-        if: ${{ hashFiles('epicshop/test.js') != '' }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - name: 🎭 Install Playwright browser
         if: ${{ hashFiles('epicshop/test.js') != '' }}
         run: npx playwright install --with-deps chromium
-
-      - name: ⎔ Restore Node 26
-        if: ${{ hashFiles('epicshop/test.js') != '' }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: 26
 
       - name: ◭ Generate Prisma clients
         if: ${{ hashFiles('epicshop/test.js') != '' }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -63,7 +63,7 @@ jobs:
           done
 
       - name: ʦ TypeScript
-        run: npm run typecheck
+        run: npm run typecheck --if-present
         working-directory: ./workshop
 
       - name: ⬣ Lint

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -88,9 +88,22 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
 
+      # Playwright 1.51 hangs while extracting Chromium under Node 26.
+      - name: ⎔ Use Node 22 for Playwright installation
+        if: ${{ hashFiles('epicshop/test.js') != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: 🎭 Install Playwright browser
         if: ${{ hashFiles('epicshop/test.js') != '' }}
         run: npx playwright install --with-deps chromium
+
+      - name: ⎔ Restore Node 26
+        if: ${{ hashFiles('epicshop/test.js') != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 26
 
       - name: ◭ Generate Prisma clients
         if: ${{ hashFiles('epicshop/test.js') != '' }}

--- a/exercises/04.router/01.solution.router/tests/client-side-routing.test.js
+++ b/exercises/04.router/01.solution.router/tests/client-side-routing.test.js
@@ -11,11 +11,9 @@ test('should display the home page and perform client-side routing', async ({
 		reloadCount++
 	})
 
-	// Wait for the page to load
-	await page.waitForSelector('a')
-
-	// Get the first link
-	const firstLink = await page.locator('a').first()
+	// Wait for the streamed search results to replace placeholder "#" links.
+	const firstLink = page.locator('a[href*="shipId="]').first()
+	await firstLink.waitFor()
 
 	// Get the href attribute of the first link
 	const href = await firstLink.getAttribute('href')

--- a/exercises/04.router/01.solution.router/tests/client-side-routing.test.js
+++ b/exercises/04.router/01.solution.router/tests/client-side-routing.test.js
@@ -12,7 +12,7 @@ test('should display the home page and perform client-side routing', async ({
 	})
 
 	// Wait for the streamed search results to replace placeholder "#" links.
-	const firstLink = page.locator('a[href*="shipId="]').first()
+	const firstLink = page.locator('a[href^="/"]').first()
 	await firstLink.waitFor()
 
 	// Get the href attribute of the first link


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- run Setup typechecking with npm's `--if-present` flag
- run the Playwright solution-test lane on Node 22 because Playwright 1.51 hangs under Node 26
- retain Node 26 validation across the Ubuntu, Windows, and macOS Setup matrix
- make the router test wait for a real pathname-based ship link instead of clicking a temporary `href="#"` placeholder
- preserve lint, solution-test, and deploy coverage

## Verification
- `git diff --check`
- Prettier checks for changed workflow/test files
- root lint passes
- `npm run typecheck --if-present` exits successfully when no script exists
- reproduced Playwright 1.51 Chromium extraction and test-runner hangs under Node 26
- first solution Playwright test passes under Node 22
- prior CI run passed 16 of 17 solution apps and exposed the router placeholder race now fixed
- CI exercises Setup across Ubuntu, Windows, and macOS plus all solution tests

## Context
The main deploy run failed all Setup matrix jobs solely because `npm run typecheck` exited with “Missing script: typecheck.” Iterating the newly enforced Test job also surfaced Playwright's Node 26 incompatibility and a deterministic test race against Suspense placeholders.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e994af70-941e-4394-976f-808e02c48241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e994af70-941e-4394-976f-808e02c48241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

